### PR TITLE
Add server deployment guide for Oracle database

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -5,10 +5,12 @@
 ### Option 1: Standard Node.js Server Deployment
 
 1. **Download and transfer your built application:**
+
    - Download the project files ([Download Project](#project-download))
    - Upload to your server
 
 2. **On your server, install Node.js (v18+) and run:**
+
    ```bash
    npm ci --only=production
    npm run build
@@ -16,6 +18,7 @@
    ```
 
 3. **Set environment variables on your server:**
+
    ```bash
    export DB_HOST=192.168.14.123
    export DB_PORT=1521
@@ -62,6 +65,7 @@ CMD ["npm", "start"]
 ```
 
 Then build and run:
+
 ```bash
 docker build -t your-app .
 docker run -p 8080:8080 \
@@ -77,27 +81,31 @@ docker run -p 8080:8080 \
 ### Option 3: PM2 Process Manager (Recommended)
 
 1. **Install PM2 globally:**
+
    ```bash
    npm install -g pm2
    ```
 
 2. **Create ecosystem file:**
+
    ```javascript
    // ecosystem.config.js
    module.exports = {
-     apps: [{
-       name: 'fusion-app',
-       script: 'dist/server/node-build.mjs',
-       instances: 1,
-       env: {
-         NODE_ENV: 'production',
-         DB_HOST: '192.168.14.123',
-         DB_PORT: '1521',
-         DB_USERNAME: 'Test2012',
-         DB_PASSWORD: 'test#1234',
-         DB_SID: 'crypto'
-       }
-     }]
+     apps: [
+       {
+         name: "fusion-app",
+         script: "dist/server/node-build.mjs",
+         instances: 1,
+         env: {
+           NODE_ENV: "production",
+           DB_HOST: "192.168.14.123",
+           DB_PORT: "1521",
+           DB_USERNAME: "Test2012",
+           DB_PASSWORD: "test#1234",
+           DB_SID: "crypto",
+         },
+       },
+     ],
    };
    ```
 
@@ -113,12 +121,12 @@ docker run -p 8080:8080 \
 ✅ **Database Access**: Direct connection to your Oracle database at 192.168.14.123  
 ✅ **Full Control**: Manage your own server environment  
 ✅ **No Network Issues**: No cloud-to-office connectivity problems  
-✅ **Oracle Client**: Install Oracle Instant Client properly  
+✅ **Oracle Client**: Install Oracle Instant Client properly
 
 ## Next Steps
 
 1. Choose your deployment method above
-2. [Download Project](#project-download) 
+2. [Download Project](#project-download)
 3. Transfer files to your server
 4. Follow the installation steps
 5. Your app will connect directly to Oracle database!
@@ -126,6 +134,7 @@ docker run -p 8080:8080 \
 ## Default Port
 
 The application runs on port **8080** by default. Access at:
+
 - `http://your-server-ip:8080`
 
 ## Troubleshooting


### PR DESCRIPTION
## Purpose

The user needs to deploy their application to a server with direct Oracle database connectivity. They have an Oracle database running on their office network (192.168.14.123:1521) and want to avoid cloud deployment issues that prevent database access. The user specifically requested Oracle-only deployment and provided their database credentials for server deployment.

## Code changes

- **Added `DEPLOYMENT_GUIDE.md`**: Comprehensive deployment guide with three deployment options:
  - Standard Node.js server deployment with environment variables and Oracle Instant Client setup
  - Docker deployment with Oracle client installation in container
  - PM2 process manager deployment with ecosystem configuration
- **Included specific database configuration**: Uses the provided Oracle database credentials (host: 192.168.14.123, port: 1521, service: crypto)
- **Added Oracle Instant Client installation steps**: Detailed instructions for Ubuntu/Debian and Docker environments
- **Provided troubleshooting section**: Common issues and solutions for server deployment

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6cba2085477145ccb2d1ab3051093ac1/aura-works)

👀 [Preview Link](https://6cba2085477145ccb2d1ab3051093ac1-aura-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6cba2085477145ccb2d1ab3051093ac1</projectId>-->
<!--<branchName>aura-works</branchName>-->