### PR TITLE
Fix base path configuration for production deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: process.env.NODE_ENV === "production" ? "/TRACKER-20BY-20CS/" : "/",
+  base: "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Purpose
The user was experiencing deployment issues where the build was failing with "Publish directory buld does not exist!" and after fixing deployment configuration, the page was showing blank. The user wanted to move away from Netlify dependency and fix the base path configuration that was causing the blank page issue in production.

## Code changes
- Removed conditional base path configuration in `vite.config.ts`
- Changed from `process.env.NODE_ENV === "production" ? "/TRACKER-20BY-20CS/" : "/"` to simply `"/"`
- This ensures consistent base path behavior across all environments and removes the GitHub Pages specific path dependency

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/00b58be4467d45279a0c5681220e88cf/stellar-garden)

👀 [Preview Link](https://00b58be4467d45279a0c5681220e88cf-stellar-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>00b58be4467d45279a0c5681220e88cf</projectId>-->
<!--<branchName>stellar-garden</branchName>-->